### PR TITLE
feat:Split the schemas structure into request and response

### DIFF
--- a/backend/app/models/request_schemas.py
+++ b/backend/app/models/request_schemas.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+# 텍스트 프롬프트 요청 모델
+class TextPromptRequest(BaseModel):
+    text: str = Field(..., description="인테리어 관련 사용자 입력 텍스트")
+    
+# 이미지 스타일 분석 요청 모델
+class ImageStyleRequest(BaseModel):
+    image_url: Optional[str] = Field(None, description="분석할 이미지의 URL")
+    
+# 객체 탐지 요청 모델
+class ObjectDetectionRequest(BaseModel):
+    image_url: Optional[str] = Field(None, description="객체 탐지를 위한 이미지 URL")
+
+# 이미지 생성 요청 모델
+class ImageGenerationRequest(BaseModel):
+    prompt: str = Field(..., description="이미지 생성을 위한 프롬프트")

--- a/backend/app/models/response_schemas.py
+++ b/backend/app/models/response_schemas.py
@@ -1,23 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional
 
-# 텍스트 프롬프트 요청 모델
-class TextPromptRequest(BaseModel):
-    text: str = Field(..., description="인테리어 관련 사용자 입력 텍스트")
-    
-# 이미지 스타일 분석 요청 모델
-class ImageStyleRequest(BaseModel):
-    image_url: Optional[str] = Field(None, description="분석할 이미지의 URL")
-    
-# 객체 탐지 요청 모델
-class ObjectDetectionRequest(BaseModel):
-    image_url: Optional[str] = Field(None, description="객체 탐지를 위한 이미지 URL")
-
-# 이미지 생성 요청 모델
-class ImageGenerationRequest(BaseModel):
-    prompt: str = Field(..., description="이미지 생성을 위한 프롬프트")
-
-
 # 프롬프트 응답 모델
 class PromptResponse(BaseModel):
     prompt: str = Field(..., description="생성된 인테리어 프롬프트") 

--- a/backend/app/routes/hancut_routes.py
+++ b/backend/app/routes/hancut_routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
-from app.models.schemas import ImageStyleRequest, ObjectDetectionRequest,  ImageGenerationResponse, ImageGenerationRequest
-from app.models.schemas import TextPromptRequest
+from app.models.request_schemas import ImageStyleRequest, ObjectDetectionRequest, TextPromptRequest
+from app.models.response_schemas import ImageGenerationResponse
 from app.routes import llm_routes, vision_routes
 from app.services.llm_service import llm_service
 from app.services.vision_service import vision_service

--- a/backend/app/routes/llm_routes.py
+++ b/backend/app/routes/llm_routes.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException
-from app.models.schemas import TextPromptRequest, PromptResponse, ImageGenerationRequest, ImageGenerationResponse
+from app.models.request_schemas import TextPromptRequest, ImageGenerationRequest
+from app.models.response_schemas import PromptResponse, ImageGenerationResponse
 from app.services.llm_service import llm_service
 
 router = APIRouter()

--- a/backend/app/routes/vision_routes.py
+++ b/backend/app/routes/vision_routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, UploadFile, File, Form
 from fastapi.responses import JSONResponse
-from app.models.schemas import ImageStyleRequest, StyleAnalysisResponse, ObjectDetectionRequest, ObjectDetectionResponse, DetectedObject
+from app.models.request_schemas import ImageStyleRequest, ObjectDetectionRequest
+from app.models.response_schemas import StyleAnalysisResponse, ObjectDetectionResponse, DetectedObject
 from app.services.vision_service import vision_service
 from typing import List
 


### PR DESCRIPTION
-기존 schemas.py를 request_schemas와 response_schemas로 구분하였습니다.
-위 변경사항이 routes 폴더 내부 파일인 hancut_route.py, llm_route.py, vision_route.py에 반영되도록 조치하였습니다.
-frontend와 backend 를 모두 실행한 후 각 기능 동작여부를 테스트해보았고, 변경사항으로 인한 이상은 탐지되지 않았습니다.

이에 PR를 생성합니다.